### PR TITLE
Fix missing type name in failure message

### DIFF
--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -175,6 +175,8 @@ MockUnexpectedOutputParameterFailure::MockUnexpectedOutputParameterFailure(Utest
         message_ += parameter.getName();
         message_ += "\" to function \"";
         message_ += functionName;
+        message_ += "\": ";
+        message_ += parameter.getType();
     }
 
     message_ += "\n";


### PR DESCRIPTION
You probably meant to do this?
